### PR TITLE
Adds $upstream_queue_time to nginx access log format

### DIFF
--- a/etc/nginx/nginx.conf.tmpl
+++ b/etc/nginx/nginx.conf.tmpl
@@ -47,6 +47,7 @@ http {
       'server_port="$server_port" '
       'upstream_addr="$upstream_addr" '
       'time_request="$request_time" '
+      'time_upstream_queue="$upstream_queue_time" '
       'time_upstream_connect="$upstream_connect_time" '
       'time_upstream_header="$upstream_header_time" '
       'time_upstream_response="$upstream_response_time"'


### PR DESCRIPTION
`$upstream_queue_time` should record the time the request is queued in the request backlog (e.g. if PHP is busy with other requests).

https://nginx.org/en/docs/http/ngx_http_upstream_module.html