### PR TITLE
Change default elastic.tenant_id value

### DIFF
--- a/etc/templates/deskpro-config.php.tmpl
+++ b/etc/templates/deskpro-config.php.tmpl
@@ -69,7 +69,7 @@ $CONFIG['elastic'] = [
     'verify_ssl' => false,
     'retries' => 3,
     'index_name' => {{ (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") | squote }},
-    'tenant_id' => {{ (getenv "DESKPRO_ES_TENANT_ID" (getenv "DESKPRO_DB_NAME" "deskpro")) | squote }},
+    'tenant_id' => {{ (getenv "DESKPRO_ES_TENANT_ID" (printf (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") "_tenant")) | squote }},
 ];
 
 #######################################################################


### PR DESCRIPTION
An ES alias can't be named the same as an index. In Deskpro, the tenant ID is used as an alias, so we need to make sure that the tenant ID isn't the same as the index name.

The defaults were such that if unspecified, the index would be 'deskpro' and the tenant ID would be whatever the DB name was -- which might also be 'deskpro'. So this change just appends '_tenant' when both values are the same.

This should be backwards compat because there is no change in behaviour if they are different. If they are the same, then it was never working anyway.