### PR TITLE
Change default elastic.tenant_id to prevent common mistake of setting same index/tenant value

### DIFF
--- a/etc/templates/deskpro-config.php.tmpl
+++ b/etc/templates/deskpro-config.php.tmpl
@@ -59,6 +59,8 @@ __VAL__,
 ];
 {{end}}
 
+{{$es_index_name:=(getenv "DESKPRO_ES_INDEX_NAME" "deskpro")}}
+{{$es_tenant_id:=(getenv "DESKPRO_ES_TENANT_ID" (getenv "DESKPRO_DB_NAME" "deskpro"))}}
 $CONFIG['elastic'] = [
     {{if getenv "DESKPRO_ES_URL"}}
     'hosts' => [{{ (getenv "DESKPRO_ES_URL") | squote }}],
@@ -68,8 +70,8 @@ $CONFIG['elastic'] = [
 
     'verify_ssl' => false,
     'retries' => 3,
-    'index_name' => {{ (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") | squote }},
-    'tenant_id' => {{ (getenv "DESKPRO_ES_TENANT_ID" (printf (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") "_tenant")) | squote }},
+    'index_name' => {{ $es_index_name | squote }},
+    'tenant_id' => {{ (printf "%s%s" $es_tenant_id (test.Ternary "_tenant" "" (eq $es_tenant_id $es_index_name))) | squote }},
 ];
 
 #######################################################################

--- a/etc/templates/deskpro-config.php.tmpl
+++ b/etc/templates/deskpro-config.php.tmpl
@@ -69,7 +69,7 @@ $CONFIG['elastic'] = [
     'verify_ssl' => false,
     'retries' => 3,
     'index_name' => {{ (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") | squote }},
-    'tenant_id' => {{ (getenv "DESKPRO_ES_TENANT_ID" (getenv "DESKPRO_DB_NAME" "deskpro")) | squote }},
+    'tenant_id' => {{ (getenv "DESKPRO_ES_TENANT_ID" (printf (getenv "DESKPRO_ES_INDEX_NAME" "deskpro") "_tenant")) | squote }},
 ];
 
 #######################################################################

--- a/test/Earthfile
+++ b/test/Earthfile
@@ -15,6 +15,7 @@ save-base-image:
 # test runs all tests
 test:
     BUILD +test-serverspec-web
+    BUILD +test-serverspec-simple-cases
     BUILD +test-autoinstall
     BUILD +test-automigrations
 
@@ -30,6 +31,15 @@ test-serverspec-web:
             && docker start test \
             && echo "Run again to verify state after rebooting" \
             && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/always spec/default_web'
+    END
+
+# test-serverspec-simplecases runs serverspec tests against the base image in web mode
+# to test 'simple' test cases. These are cases that don't require any special setup.
+test-serverspec-simple-cases:
+    FROM earthly/dind:alpine
+    WITH DOCKER --load deskpro/docker-product-base:test=+base-image
+        RUN docker run -d --name test deskpro/docker-product-base:test web \
+            && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/cases/simple'
     END
 
 # test-autoinstall checks the behaviour of AUTO_RUN_INSTALLER=true to ensure

--- a/test/serverspec/spec/cases/simple/sc-130148_spec.rb
+++ b/test/serverspec/spec/cases/simple/sc-130148_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "Case SC-130148: Default ES values" do
+  before(:all) do
+    system('/usr/local/bin/is-ready --check-tasks --wait --timeout 60 -v') or raise "is-ready failed"
+  end
+
+  after(:all) do
+    ENV.delete('DESKPRO_ES_TENANT_ID')
+    ENV.delete('DESKPRO_ES_INDEX_NAME')
+  end
+
+  it "DESKPRO_ES_TENANT_ID will suffix _tenant if it conflicts with DESKPRO_ES_INDEX_NAME" do
+    ENV['DESKPRO_ES_INDEX_NAME'] = 'deskpro'
+    ENV['DESKPRO_ES_TENANT_ID'] = 'deskpro'
+    output = `eval-tpl -f /etc/templates/deskpro-config.php.tmpl`
+    expect(output).to contain "'index_name' => 'deskpro'"
+    expect(output).to contain "'tenant_id' => 'deskpro_tenant'"
+  end
+
+  it "DESKPRO_ES_TENANT_ID will be used as-is if there is no conflict" do
+    ENV['DESKPRO_ES_INDEX_NAME'] = 'deskpro'
+    ENV['DESKPRO_ES_TENANT_ID'] = 'foo'
+    output = `eval-tpl -f /etc/templates/deskpro-config.php.tmpl`
+    expect(output).to contain "'index_name' => 'deskpro'"
+    expect(output).to contain "'tenant_id' => 'foo'"
+  end
+end


### PR DESCRIPTION
An ES alias can't be named the same as an index. In Deskpro, the tenant ID is used as an alias, so we need to make sure that the tenant ID isn't the same as the index name.

The defaults are such that if unspecified, the index would be 'deskpro' and the tenant ID would be whatever the DB name was -- which might also be 'deskpro'.

The fix here is to append `_tenant` if the index/tenant values are the same.

---

This should be backwards compatible because there's no change in values unless the index/tenant are equal. And if they are currently equal in a deployed instance, then elastic already does not work.