### PR TITLE
fix reboot on opc

### DIFF
--- a/test/Earthfile
+++ b/test/Earthfile
@@ -15,6 +15,7 @@ save-base-image:
 # test runs all tests
 test:
     BUILD +test-serverspec-web
+    BUILD +test-serverspec-opc
     BUILD +test-serverspec-simple-cases
     BUILD +test-custom-configs
     BUILD +test-autoinstall
@@ -27,6 +28,19 @@ test-serverspec-web:
     FROM earthly/dind:alpine
     WITH DOCKER --load deskpro/docker-product-base:test=+base-image
         RUN docker run -d --name test deskpro/docker-product-base:test web \
+            && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/always spec/default_web' \
+            && docker stop test \
+            && docker start test \
+            && echo "Run again to verify state after rebooting" \
+            && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/always spec/default_web'
+    END
+
+# test-serverspec-opc runs opc specific tests
+# TODO - currently just runs same as +test-serverspec-web but in opc mode
+test-serverspec-opc:
+    FROM earthly/dind:alpine
+    WITH DOCKER --load deskpro/docker-product-base:test=+base-image
+        RUN docker run -d --name test -e DESKPRO_OPC_WEBGUI_BASEURL=http://localhost:29443 deskpro/docker-product-base:test web \
             && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/always spec/default_web' \
             && docker stop test \
             && docker start test \

--- a/usr/local/sbin/entrypoint.d/05-opc.sh
+++ b/usr/local/sbin/entrypoint.d/05-opc.sh
@@ -73,7 +73,7 @@ bc_opc_2_8() {
   fi
 
   boot_log_message DEBUG "[bc_opc_2_8] Linking /run/php-fpm/dp_default.sock -> /run/php_fpm_dp_default.sock"
-  mkdir /run/php-fpm
+  mkdir -p /run/php-fpm
   ln -sf /run/php_fpm_dp_default.sock /run/php-fpm/dp_default.sock
 
   for pool in "dp_broadcaster" "dp_default" "dp_gql" "dp_internal"; do


### PR DESCRIPTION
Fixes error on boot when container is rebooted

```
mkdir: cannot create directory '/run/php-fpm': File exists
```

Also added `+test-serverspec-opc` test. Currently just runs normal 'web' tests, just with 'OPC' mode enabled to catch issues like this one.