### PR TITLE
Repointing envs/settings for messenger service

### DIFF
--- a/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
+++ b/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
@@ -292,7 +292,7 @@ $CONFIG['services'] = [];
 {{if getenv "SVC_PHP_FPM_ENABLED"}}
 $CONFIG['services'] = [
     'deskpro-messenger' => [
-        'base_url' => {{ (getenv "SVC_MESSENGER_BASE_URL" "http://127.0.0.1:25000") | squote }},
+        'base_url' => {{ (getenv "SVC_MESSENGER_BASE_URL" "http://127.0.0.1:24000") | squote }},
     ]
 ];
 {{end}}

--- a/usr/local/share/deskpro/templates/svc-deskpro-messenger.env.tmpl
+++ b/usr/local/share/deskpro/templates/svc-deskpro-messenger.env.tmpl
@@ -7,5 +7,5 @@ NEXTAUTH_SECRET={{ crypto.SHA512 (printf "deskpro-services-messenger-api-private
 # but next will use this to set cookie props (e.g. path) so we need to set it.
 NEXTAUTH_URL=https://BEBAF3DB-8FF3-415D-BEF2-205F6945B03B/deskpro-messenger
 
-NEXTAUTH_URL_INTERNAL=http://127.0.0.1:24000
-MESSENGER_API_PRIVATE_URL=http://127.0.0.1:25000
+NEXTAUTH_URL_INTERNAL=http://127.0.0.1:25000
+MESSENGER_API_PRIVATE_URL=http://127.0.0.1:24000


### PR DESCRIPTION
 the default should be messenger_api,

envs are pointing to the wrong messenger service