### PR TITLE
Actually needs to be the /static/ path

### DIFF
--- a/etc/nginx/conf.d/deskpro_server_params
+++ b/etc/nginx/conf.d/deskpro_server_params
@@ -63,7 +63,7 @@ location ~ /assets/[a-zA-Z0-9_\-\.]+/(pub|web)/.*?$ {
     }
 }
 
-location ^~ /deskpro-messenger-init/ {
+location ^~ /static/ {
     add_header 'Access-Control-Allow-Origin' '*';
     add_header 'Access-Control-Allow-Headers' '*';
     add_header 'Access-Control-Allow-Methods' 'GET,OPTIONS';


### PR DESCRIPTION
After further discussion this rule block needs to be applied to /static/ rather than /deskpro-messenger-init/ to align with other work being done in product