### PR TITLE
Miscellaneous fixes after testing on Support

### DIFF
--- a/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
+++ b/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
@@ -291,9 +291,7 @@ $CONFIG['services'] = [];
 
 {{if getenv "SVC_PHP_FPM_ENABLED"}}
 $CONFIG['services'] = [
-    'deskpro-messenger' => [
-        'base_url' => {{ (getenv "SVC_MESSENGER_BASE_URL" "http://127.0.0.1:24000") | squote }},
-    ]
+    'deskpro-messenger' => []
 ];
 {{end}}
 


### PR DESCRIPTION
1. Removing `services.deskpro-messenger.base_url` to remove this error in the PHP error log
```
ts=2024-04-18T13:38:12Z app=php chan=error lvl=ERROR msg="DEPRECATED: services.deskpro-messenger.base_url is deprecated. Use api_urls.deskpro-services-messenger-api[-private] instead." container_name=deskpro_helpdesk_web
```