### PR TITLE
Chore/sc 153325/test custom opc configs on new docker container

### DIFF
--- a/usr/local/sbin/entrypoint.d/05-opc.sh
+++ b/usr/local/sbin/entrypoint.d/05-opc.sh
@@ -48,7 +48,7 @@ opc_main() {
       cat "/deskpro/config/${pool}.conf" \
         | sed 's/^user = php$/user = dp_app/g' \
         | sed 's/^group = php$/group = dp_app/g' \
-        | sed "s/^listen = \/run\/php-fpm\/${pool}.sock/listen = \/run\/php_fpm_${pool}.sock/g" \
+        | sed "s/^listen = \/run\/php-fpm\/${pool}.sock$/listen = \/run\/php_fpm_${pool}.sock/g" \
       > "/etc/php/8.3/fpm/pool.d/zz_${pool}.conf"
     fi
   done

--- a/usr/local/sbin/entrypoint.d/05-opc.sh
+++ b/usr/local/sbin/entrypoint.d/05-opc.sh
@@ -43,7 +43,13 @@ opc_main() {
   for pool in "dp_broadcaster" "dp_default" "dp_gql" "dp_internal"; do
     if [ -e "/deskpro/config/${pool}.conf" ]; then
       boot_log_message DEBUG "[bc_opc_2_8] Copying /deskpro/config/${pool}.conf to /etc/php/8.3/fpm/pool.d/zz_${pool}.conf"
-      cp -f "/deskpro/config/${pool}.conf" "/etc/php/8.3/fpm/pool.d/zz_${pool}.conf"
+
+      # copy the config and perform in-place modifications to ensure that the config is valid
+      cat "/deskpro/config/${pool}.conf" \
+        | sed 's/^user = php$/user = dp_app/g' \
+        | sed 's/^group = php$/group = dp_app/g' \
+        | sed "s/^listen = \/run\/php-fpm\/${pool}.sock/listen = \/run\/php_fpm_${pool}.sock/g" \
+      > "/etc/php/8.3/fpm/pool.d/zz_${pool}.conf"
     fi
   done
 }

--- a/usr/local/sbin/entrypoint.d/50-patches.sh
+++ b/usr/local/sbin/entrypoint.d/50-patches.sh
@@ -8,7 +8,7 @@ patches_main() {
   install_patches "0.0.0"
 
   # but normally only apply patches for the same version
-  if [ -d "/srv/deskpro/deskpro-build.json" ]; then
+  if [ -f "/srv/deskpro/deskpro-build.json" ]; then
     deskpro_version=$(jq -r '.build.coreVersion' /srv/deskpro/deskpro-build.json)
     install_patches "$deskpro_version"
   fi


### PR DESCRIPTION
Updates after testing on OPC for custom configs.
1. Correct the check for file existence of `deskpro-build.json` so patches can be loaded in.
2. Perform in-line replacements of the provided FPM config pool files (if provided) to ensure that they actually load. Errors without this were:
```
==> /opt/deskpro/data/instances/testinst/logs/deskpro_testinst_web-php_fpm.process.log <==
ts=2024-05-30T10:07:29Z app=php_fpm chan=process lvl=INFO msg="[30-May-2024 10:07:28] ERROR: [pool dp_default] cannot get uid for user 'php'" container_name=deskpro_testinst_web
ts=2024-05-30T10:07:29Z app=php_fpm chan=process lvl=INFO msg="[30-May-2024 10:07:28] ERROR: FPM initialization failed" container_name=deskpro_testinst_web
```
and
```
==> /opt/deskpro/data/instances/testinst/logs/deskpro_testinst_web-nginx.error.log <==
ts=2024-05-30T10:07:29Z app=nginx chan=error lvl=CRIT msg="connect() to unix:/run/php_fpm_dp_gql.sock failed (2: No such file or directory) while connecting to upstream" container_name=deskpro_testinst_web cid=17 client=192.168.70.3 host=192.168.80.79 pid=1171 referer=https://192.168.80.79/app request="POST /agent-api/graphql/BcConnectToken HTTP/1.1" server=_ tid=1171 upstream=fastcgi://unix:/run/php_fpm_dp_gql.sock:
```