### PR TITLE
Add multiplatform build hook

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker buildx create --name multiarch --driver docker-container --use
+docker buildx build --platform linux/arm64,linux/amd64 --build-arg BUILDKIT_MULTI_PLATFORM=1 -f $DOCKERFILE_PATH -t $IMAGE_NAME --push .

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Nothing to push at this stage, already pushed as part of the multiplatform build step"


### PR DESCRIPTION
Create new build hook with a new buildx context

push from the build hook because it's a multiplatform buildx build

push hook fails as buildx already pushes so change from the default hook