### PR TITLE
bug/sc-155796/any-node-a-user-interacts-with-fails-to-send

### DIFF
--- a/etc/nginx/conf.d/deskpro_server_params
+++ b/etc/nginx/conf.d/deskpro_server_params
@@ -30,12 +30,12 @@ location ^~ /sys/services/broadcaster/ {
     include /etc/nginx/conf.d/deskpro_fastcgi_params;
 }
 
-location ~ ^/(admin\-api|agent\-api|sys/services)/ {
+location ~ ^/(admin\-api|agent\-api)/ {
     fastcgi_pass unix:/run/php_fpm_dp_gql.sock;
     include /etc/nginx/conf.d/deskpro_fastcgi_params;
 }
 
-location ^~ /sys/services/search-indexing/ {
+location ~ ^/(ticket\-channels|sys/services)/ {
     fastcgi_pass unix:/run/php_fpm_dp_internal.sock;
     include /etc/nginx/conf.d/deskpro_fastcgi_params;
 }


### PR DESCRIPTION
Change `/sys/services` and `ticket-messages` endpoints to use the `dp_internal` (relatively unlimited) fpm pool to avoid issues with FPM child processes that Russell was seeing:
```
ts=2024-06-24T12:57:02Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_default] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:19:50Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:20:09Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_default] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:29:25Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:31:46Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_default] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:35:26Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:38:02Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_default] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:39:42Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:48:15Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:55:19Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T13:56:50Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_default] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T14:01:24Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
ts=2024-06-24T14:06:20Z app=php_fpm chan=error lvl=WARNING msg="[pool dp_gql] server reached max_children setting (20), consider raising it" container_name=deskpro_helpdesk_web
```
and 
```
Failed workflow:
GuzzleHttp\Exception\ConnectException: cURL error 28: Operation timed out after 10003 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://127.0.0.1/ticket-channels/v1/conversation/9c5d1f4e-d05a-40a0-b0c5-7f7b19621c4c/ticket
[1:21](https://deskpro.slack.com/archives/D034U44E0TA/p1719318064595619)
This is on support
1:21
cURL error 28: Operation timed out after 10003 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://127.0.0.1/sys/services/workflow-engine/chatbot/workflow/2/execute
```