### PR TITLE
Clean up log file export

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git/
 .scratch/
+hooks/
+test/
 
 .editorconfig
 .gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:12.2-slim as builder-php-exts
+# builder stage -- builds PHP packages
+# outputs: /usr/lib/php/20230831/protobuf.so
+# outputs: /usr/lib/php/20230831/opentelemetry.so
+FROM debian:12.2-slim AS builder-php-exts
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates apt-transport-https software-properties-common curl lsb-release \
     && curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
@@ -13,14 +16,12 @@ RUN apt-get update \
     php-pear \
     && pecl install opentelemetry protobuf \
     && rm -rf /var/lib/apt/lists/*
-# outputs: /usr/lib/php/20230831/protobuf.so
-# outputs: /usr/lib/php/20230831/opentelemetry.so
 
-FROM debian:12.2-slim
+# stage1 -- debian with packages
+FROM debian:12.2-slim AS stage1
 ENV TZ=UTC
 WORKDIR /srv/deskpro
 USER root
-
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests ca-certificates apt-transport-https software-properties-common curl lsb-release \
     && curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
@@ -64,7 +65,20 @@ RUN apt-get update \
     && find /usr/lib/python3.11 -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete \
     && apt-get -y autoremove && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/bin/mariadb-access /usr/bin/mariadb-admin /usr/bin/mariadb-analyze /usr/bin/mariadb-check /usr/bin/mariadb-binlog /usr/bin/mariadb-conv /usr/bin/mariadb-convert-table-format /usr/bin/mariadb-find-rows /usr/bin/mariadb-fix-extensions /usr/bin/mariadb-hotcopy /usr/bin/mariadb-import /usr/bin/mariadb-optimize /usr/bin/mariadb-plugin /usr/bin/mariadb-repair /usr/bin/mariadb-report /usr/bin/mariadb-secure-installation /usr/bin/mariadb-setpermission /usr/bin/mariadb-show /usr/bin/mariadb-slap /usr/bin/mariadb-tzinfo-to-sql /usr/bin/mariadb-waitpid /usr/bin/mariadbcheck
+    && rm -rf /usr/bin/mariadb-access /usr/bin/mariadb-admin /usr/bin/mariadb-analyze /usr/bin/mariadb-check /usr/bin/mariadb-binlog /usr/bin/mariadb-conv /usr/bin/mariadb-convert-table-format /usr/bin/mariadb-find-rows /usr/bin/mariadb-fix-extensions /usr/bin/mariadb-hotcopy /usr/bin/mariadb-import /usr/bin/mariadb-optimize /usr/bin/mariadb-plugin /usr/bin/mariadb-repair /usr/bin/mariadb-report /usr/bin/mariadb-secure-installation /usr/bin/mariadb-setpermission /usr/bin/mariadb-show /usr/bin/mariadb-slap /usr/bin/mariadb-tzinfo-to-sql /usr/bin/mariadb-waitpid /usr/bin/mariadbcheck \
+    && ln -s /usr/bin/vim.tiny /usr/bin/vim
+
+# stage2 -- packages from other images
+FROM stage1 AS stage2
+COPY --from=builder-php-exts /usr/lib/php/20230831/protobuf.so /usr/lib/php/20230831/protobuf.so
+COPY --from=builder-php-exts /usr/lib/php/20230831/opentelemetry.so /usr/lib/php/20230831/opentelemetry.so
+COPY --from=hairyhenderson/gomplate:v3.11.5 /gomplate /usr/local/bin/gomplate
+COPY --from=composer:2.5.8 /usr/bin/composer /usr/local/bin/composer
+COPY --from=timberio/vector:0.39.0-debian /usr/bin/vector /usr/local/bin/vector
+COPY --from=node:18.19-bookworm /usr/local/bin /usr/local/bin
+COPY --from=node:18.19-bookworm /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN npm install --global tsx
 
 RUN sed -i 's/providers = provider_sect/providers = provider_sect\n\
 ssl_conf = ssl_sect\n\
@@ -74,18 +88,6 @@ system_default = system_default_sect\n\
 \n\
 [system_default_sect]\n\
 Options = UnsafeLegacyRenegotiation/' /etc/ssl/openssl.cnf
-
-COPY --from=builder-php-exts /usr/lib/php/20230831/protobuf.so /usr/lib/php/20230831/protobuf.so
-COPY --from=builder-php-exts /usr/lib/php/20230831/opentelemetry.so /usr/lib/php/20230831/opentelemetry.so
-
-COPY --from=hairyhenderson/gomplate:v3.11.5 /gomplate /usr/local/bin/gomplate
-COPY --from=composer:2.5.8 /usr/bin/composer /usr/local/bin/composer
-COPY --from=timberio/vector:0.31.0-debian /usr/bin/vector /usr/local/bin/vector
-COPY --from=oven/bun:1.0.14-debian /usr/local/bin/bun /usr/local/bin/bun
-
-COPY --from=node:18.19-bookworm /usr/local/bin /usr/local/bin
-COPY --from=node:18.19-bookworm /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN npm install --global tsx
 
 RUN set -e \
     && printf '; priority=20\nextension=protobuf.so' > /etc/php/8.3/mods-available/protobuf.ini \
@@ -100,6 +102,8 @@ RUN set -e \
     && chmod 0755 /etc/nginx /etc/nginx/conf.d \
     && mv /tmp/mime.types /etc/nginx
 
+# build -- final stage adds our custom stuff
+FROM stage2 AS build
 COPY etc /etc/
 COPY usr/local/bin /usr/local/bin/
 COPY usr/local/lib /usr/local/lib/
@@ -107,18 +111,18 @@ COPY usr/local/sbin /usr/local/sbin/
 COPY usr/local/share/deskpro /usr/local/share/deskpro/
 
 RUN set -e \
-    # dp_app user is used when we run any app code (e.g. php-fpm, CLI tasks, etc) \
+    # dp_app user is used when we run any app code (e.g. php-fpm, CLI tasks, etc)
     && addgroup --gid 1083 dp_app \
     && adduser --system --shell /bin/false --no-create-home --disabled-password --uid 1083 --gid 1083 dp_app \
-    # vector user for logs \
+    # vector user for logs
     && addgroup --gid 1084 vector \
     && adduser --system --shell /bin/false --no-create-home --disabled-password --uid 1084 --gid 1084 vector \
-    # add vector to adm group so it can read logs \
+    # add vector to adm group so it can read logs
     && usermod -a -G adm vector \
-    # we run nginx as its own user \
+    # we run nginx as its own user
     && addgroup --gid 1085 nginx \
     && adduser --system --shell /bin/false --no-create-home --disabled-password --uid 1085 --gid 1085 nginx \
-    # initialize dirs and owners \
+    # initialize dirs and owners
     && mkdir -p /var/log/nginx /var/log/php /var/log/deskpro /var/log/supervisor /var/lib/vector \
     && mkdir -p /srv/deskpro/INSTANCE_DATA/deskpro-config.d \
     && chown root:root /usr/local/bin/vector \
@@ -126,11 +130,11 @@ RUN set -e \
     && chown nginx:adm /var/log/nginx \
     && chown dp_app:adm /var/log/php /var/log/deskpro \
     && chmod -R 0775 /var/log/php /var/log/deskpro \
-    # set group sticky bit on these dirs so \
-    # new logs get created with adm group (so vector can read them) \
+    # set group sticky bit on these dirs so
+    # new logs get created with adm group (so vector can read them)
     && chmod g+s /var/log/nginx /var/log/php /var/log/deskpro \
-    # extract var names from our reference list \
-    # (these lists are used from various helper scripts or entrypoint scripts) \
+    # extract var names from our reference list
+    # (these lists are used from various helper scripts or entrypoint scripts)
     && jq -r '.[] | select(.isPrivate|not) | .name' /usr/local/share/deskpro/container-var-reference.json > /usr/local/share/deskpro/container-public-var-list \
     && jq -r '.[] | select(.isPrivate) | .name' /usr/local/share/deskpro/container-var-reference.json > /usr/local/share/deskpro/container-private-var-list \
     && jq -r '.[] | select(.setEnv) | .name' /usr/local/share/deskpro/container-var-reference.json > /usr/local/share/deskpro/container-setenv-var-list \
@@ -170,10 +174,10 @@ ENV LOGS_EXPORT_TARGET ""
 ENV LOGS_EXPORT_DIR ""
 
 # The filename to use when writing logs to LOGS_EXPORT_DIR
-ENV LOGS_EXPORT_FILENAME "{{.container_name}}-{{.app}}.log"
+ENV LOGS_EXPORT_FILENAME "{{.container_name}}-{{.log_group}}.log"
 
-# Log output format: logfmt or json
-ENV LOGS_OUTPUT_FORMAT "json"
+# Enable ("1" or "true") to enable fast shutdown (don't wait for all processes to finish gracefully)
+ENV FAST_SHUTDOWN="0"
 
 # GID to use for exported log files. By default, logs will be owned by the vector group (GID 1084).
 ENV LOGS_GID ""

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,10 +170,10 @@ ENV LOGS_EXPORT_TARGET ""
 ENV LOGS_EXPORT_DIR ""
 
 # The filename to use when writing logs to LOGS_EXPORT_DIR
-ENV LOGS_EXPORT_FILENAME "{{.container_name}}/{{.app}}/{{.chan}}.log"
+ENV LOGS_EXPORT_FILENAME "{{.container_name}}-{{.app}}.log"
 
 # Log output format: logfmt or json
-ENV LOGS_OUTPUT_FORMAT "logfmt"
+ENV LOGS_OUTPUT_FORMAT "json"
 
 # GID to use for exported log files. By default, logs will be owned by the vector group (GID 1084).
 ENV LOGS_GID ""

--- a/etc/nginx/nginx.conf.tmpl
+++ b/etc/nginx/nginx.conf.tmpl
@@ -26,33 +26,34 @@ http {
     ssl_session_timeout 1h;
     ssl_session_tickets off;
 
-    log_format logfmt escape=json
-      'ts=$time_iso8601 '
-      'method=$request_method '
-      'request_uri="$request_uri" '
-      'status=$status '
-      'host="$host" '
-      'scheme=$scheme '
-      'user_http_referer="$http_referer" '
-      'user_agent="$http_user_agent" '
-      'user_remote_addr=$remote_addr '
-      'user_remote_port=$remote_port '
-      'proxy_addr=$realip_remote_addr '
-      'proxy_port=$realip_remote_port '
-      'request_id="$request_id" '
-      'request_log_transaction_id="$http_x_log_transaction_id" '
-      'bytes_request="$request_length" '
-      'bytes_response="$body_bytes_sent" '
-      'server_protocol="$server_protocol" '
-      'server_port="$server_port" '
-      'upstream_addr="$upstream_addr" '
-      'time_request="$request_time" '
-      'time_upstream_connect="$upstream_connect_time" '
-      'time_upstream_header="$upstream_header_time" '
-      'time_upstream_response="$upstream_response_time"'
-      ;
+    log_format logjson escape=json
+      '{'
+      '"ts":"$time_iso8601", '
+      '"method":"$request_method", '
+      '"request_uri":"$request_uri", '
+      '"status":"$status", '
+      '"host":"$host", '
+      '"scheme":"$scheme", '
+      '"user_http_referer":"$http_referer", '
+      '"user_agent":"$http_user_agent", '
+      '"user_remote_addr":"$remote_addr", '
+      '"user_remote_port":"$remote_port", '
+      '"proxy_addr":"$realip_remote_addr", '
+      '"proxy_port":"$realip_remote_port", '
+      '"request_id":"$request_id", '
+      '"request_log_transaction_id":"$http_x_log_transaction_id", '
+      '"bytes_request":"$request_length", '
+      '"bytes_response":"$body_bytes_sent", '
+      '"server_protocol":"$server_protocol", '
+      '"server_port":"$server_port", '
+      '"upstream_addr":"$upstream_addr", '
+      '"time_request":"$request_time", '
+      '"time_upstream_connect":"$upstream_connect_time", '
+      '"time_upstream_header":"$upstream_header_time", '
+      '"time_upstream_response":"$upstream_response_time"'
+      '}';
 
-    access_log /var/log/nginx/access.log logfmt;
+    access_log /var/log/nginx/access.log logjson;
     error_log /var/log/nginx/error.log {{ getenv "NGINX_ERROR_LOG_LEVEL" "warn" }};
 
     include /etc/nginx/conf.d/*.conf;

--- a/etc/supervisor/conf.d/email.conf.tmpl
+++ b/etc/supervisor/conf.d/email.conf.tmpl
@@ -18,11 +18,11 @@ group=dp_app
 startsecs=1
 numprocs={{ getenv "SVC_EMAIL_COLLECT_NUMPROCS" "1" }}
 stopsignal=INT
-stopwaitsecs=30
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "30" }}
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/email_collect.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 
 [program:email_process]
 process_name=%(program_name)s_%(process_num)02d
@@ -35,8 +35,8 @@ group=dp_app
 startsecs=1
 numprocs={{ getenv "SVC_EMAIL_PROCESS_NUMPROCS" "1" }}
 stopsignal=INT
-stopwaitsecs=30
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "30" }}
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/email_process.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0

--- a/etc/supervisor/conf.d/logging.conf.tmpl
+++ b/etc/supervisor/conf.d/logging.conf.tmpl
@@ -1,24 +1,21 @@
 [program:vector]
-command=/usr/local/bin/vector --quiet --config /etc/vector/vector.toml --config /etc/vector/vector.d/*.toml --color never --log-format json
+command=/usr/local/bin/vector --watch-config --config /etc/vector/vector.toml --config /etc/vector/vector.d/*.toml --color never --log-format json
 user=vector
 umask=002
 numprocs=1
 startsecs=0
 autostart=true
 autorestart=true
-# output would be from console sink, which we want to pass
-# on to stdout on the container (which would get consumed by docker logs)
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0
-redirect_stderr=false
+redirect_stderr=true
+stdout_logfile=/var/log/vector.log
+stdout_logfile_maxbytes=10000000
+stdout_logfile_backups=0
 stopsignal=TERM
-stopwaitsecs=8
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "8" }}
 # makes vector start first and shut down last so it
 # will read logs from other processes during shutdown
 priority=0
-environment=VECTOR_MARKER="{{ getenv "VECTOR_MARKER" "" }}"
+environment=VECTOR_MARKER="{{ getenv "VECTOR_MARKER" "" }}",VECTOR_COLOR=never
 
 [eventlistener:rotate_logs]
 command=/etc/supervisor/rotate-logs
@@ -26,8 +23,8 @@ events=TICK_60
 autorestart=true
 buffer_size=1
 stderr_logfile=/var/log/supervisor/rotate_logs.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 stopsignal=KILL
 stopwaitsecs=0
 environment=VECTOR_MARKER="{{ getenv "VECTOR_MARKER" "" }}"

--- a/etc/supervisor/conf.d/messenger.conf.tmpl
+++ b/etc/supervisor/conf.d/messenger.conf.tmpl
@@ -5,10 +5,11 @@ autorestart=true
 exitcodes=0
 user=dp_app
 group=dp_app
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "10" }}
 startsecs=1
 startretries=3
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/svc_messenger_api.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 environment=HOSTNAME=127.0.0.1,PORT=24000

--- a/etc/supervisor/conf.d/tasks.conf.tmpl
+++ b/etc/supervisor/conf.d/tasks.conf.tmpl
@@ -9,8 +9,8 @@ startsecs=1
 stopsignal=INT
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/tasks.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 stopsignal=TERM
-stopwaitsecs=60
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "60" }}
 environment=CRON_STATUS_FILEPATH="{{ getenv "CRON_STATUS_FILEPATH" "" }}"

--- a/etc/supervisor/conf.d/web.conf.tmpl
+++ b/etc/supervisor/conf.d/web.conf.tmpl
@@ -7,14 +7,14 @@ startsecs=1
 startretries=3
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/nginx.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 {{if conv.ToBool (getenv "HTTP_INTERNAL_MODE") }}
 stopsignal=TERM
 stopwaitsecs=0
 {{else}}
 stopsignal=QUIT
-stopwaitsecs=60
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "60" }}
 {{end}}
 
 [program:php_fpm]
@@ -26,12 +26,12 @@ startsecs=1
 startretries=3
 redirect_stderr=true
 stdout_logfile=/var/log/supervisor/php_fpm.log
-stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=1
+stdout_logfile_maxbytes=0 {{/* Our rotate-logs task will handle rotation */}}
+stdout_logfile_backups=0
 {{if conv.ToBool (getenv "HTTP_INTERNAL_MODE") }}
 stopsignal=TERM
 stopwaitsecs=0
 {{else}}
 stopsignal=TERM
-stopwaitsecs=60
+stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "60" }}
 {{end}}

--- a/etc/supervisor/rotate-logs
+++ b/etc/supervisor/rotate-logs
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # This command is run every 60 seconds (see conf.d/logging.conf rotate_logs event listener)
-# This will read log files and rotate them from mylog.log to mylog.log.1 if they are 10MB or larger.
+# This will read log files and rotate them from mylog.log to mylog.log.1 if they are 15MB or larger.
 #
-# This is because the logs in the filesystem are only meant to be temporary buffers.
+# This is because the logs in the filesystem are only meant to be temporary.
 #
 # Vector is used to process and ship the logs elsewhere. Most commonly this will
 # be by outputting all logs to stdout (e.g. for docker logs) or to output them
@@ -19,16 +19,16 @@ while read -r header; do
   read -r -n "$bytes" event
   echo "$event" >&2
 
-  find /var/log -type f -name '*.log' -size +10M -not -path /var/log/docker-logs | while read f; do
+  find /var/log -type f -name '*.log' -size +15M -not -path /var/log/docker-logs | while read f; do
     echo "Rotating $f ($(stat -c%s "$f"))" >&2
-    copy "$f" "$f.1"
-    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] Log file started: $f -- ${VECTOR_MARKER}" > "$f"
-  done
 
-  # always correct log files in /var/log/deskpro
-  # (e.g. if someone ran script as root it could create a *new* log file)
-  find /var/log/deskpro -type f -name '*.log' -not -user dp_app | while read f; do
-    chown dp_app:adm "$f"
+    # Copy this file then truncate it below (i.e. analogous to logrotate copytruncate)
+    copy "$f" "$f.1"
+
+    # Vector uses the first line to determine if a file was changed
+    # So this first line would change (new time) so Vector knows to re-process the file
+    # (VECTOR_MARKER is used from our transformations to know we can ignore the line itself)
+    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] Log file started: $f -- ${VECTOR_MARKER}" > "$f"
   done
 
   printf "RESULT 2\nOK"

--- a/etc/supervisor/supervisord-exit-on-failure
+++ b/etc/supervisor/supervisord-exit-on-failure
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This script is used to exit the container if a process fails to start properly (i.e. becomes unhealthy)
+
 printf "READY\n";
 
 while read -r header; do
@@ -8,7 +10,7 @@ while read -r header; do
   echo "------------------------------" >&2
   echo "" >&2
   echo "" >&2
-  
+
   echo "$header" >&2
   bytes=$(echo "$header" | sed 's/.*\://')
   read -r -n "$bytes" event

--- a/etc/vector/vector.d/10-deskpro-app.toml
+++ b/etc/vector/vector.d/10-deskpro-app.toml
@@ -1,3 +1,5 @@
+# Deskpro application logs - from Laravel/Symfony
+# Contain things like exception traces or other interesting events via loggers
 [sources.deskpro_logs_raw]
 type = "file"
 include = ["/var/log/deskpro/*.log", "/var/log/deskpro/*.log.1"]
@@ -11,6 +13,7 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "deskpro-app"
 .app = "deskpro"
 .chan = "general"
 .lvl = "ERROR"
@@ -26,7 +29,9 @@ if !is_nullish(object(json) ?? null) {
   .lvl = string(json.level_name) ?? string(json.level) ?? "ERROR"
 
   if !is_nullish(string(json.datetime.date) ?? null) {
-    .ts = to_timestamp(string(json.datetime.date) ?? null) ?? null
+    .ts = parse_timestamp(string(json.datetime.date) ?? null, "%+") ?? null
+  } else if !is_nullish(string(json.datetime) ?? null) {
+    .ts = parse_timestamp(string(json.datetime) ?? null, "%+") ?? null
   }
 
   request_id = string(json.context.request_id) ?? string(json.extra.request_id) ?? null

--- a/etc/vector/vector.d/10-deskpro-services.toml
+++ b/etc/vector/vector.d/10-deskpro-services.toml
@@ -1,12 +1,18 @@
-[sources.deskpro_tasks_raw]
+# stdout from deskpro services - these are processes run by supervisor whose output is considered their log output
+[sources.deskpro_services_raw]
 type = "file"
 include = [
+  # cron wrapper that runs many CLI commands
   "/var/log/supervisor/tasks.log",
   "/var/log/supervisor/tasks.log.1",
+
+  # email collection/processing wrapper
   "/var/log/supervisor/email_collect.log",
   "/var/log/supervisor/email_collect.log.1",
   "/var/log/supervisor/email_process.log",
   "/var/log/supervisor/email_process.log.1",
+
+  # node services stdout
   "/var/log/supervisor/svc_messenger.log",
   "/var/log/supervisor/svc_messenger.log.1",
   "/var/log/supervisor/svc_messenger_api.log",
@@ -15,24 +21,36 @@ include = [
 ignore_not_found = true
 max_line_bytes = 2000000
 
-[transforms.deskpro_tasks]
+[transforms.deskpro_services]
 type = "remap"
-inputs = ["deskpro_tasks_raw"]
+inputs = ["deskpro_services_raw"]
 source = '''
 if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKER")) {
   abort
 }
 
 parsedName = parse_regex(.file, r'/(?P<filename>[\w\.\-]+)\.log(\.\d+)?$') ?? {}
-
 appFromName = string(parsedName.filename) ?? null
 
 if !is_nullish(appFromName) {
-  .app = "deskpro-tasks-" + appFromName
+  .app = "deskpro-" + appFromName
+  .log_group = appFromName
 } else {
   .app = "deskpro-tasks"
+  .log_group = "tasks"
 }
 
+# note: not all lines will always be JSON
 .parsed = parse_json(.message) ?? {}
-.chan = string(.parsed.channel) ?? "process"
+.chan = string(.parsed.channel) ?? "general"
+
+if !is_nullish(.parsed.time) {
+  # node services output a "time" property
+  .ts = parse_timestamp(string(.parsed.time) ?? null, "%+") ?? null
+  del(.parsed.time)
+} else if !is_nullish(.parsed.datetime) {
+  # email proc services may output a "datetime" property
+  .ts = parse_timestamp(string(.parsed.datetime) ?? null, "%+") ?? null
+  del(.parsed.datetime)
+}
 '''

--- a/etc/vector/vector.d/10-nginx.toml
+++ b/etc/vector/vector.d/10-nginx.toml
@@ -1,23 +1,28 @@
-[sources.nginx_access_logfmt]
+# nginx access logs
+[sources.nginx_access_raw]
 type = "file"
 include = ["/var/log/nginx/access.log", "/var/log/log/nginx/access.log.1"]
 ignore_not_found = true
 
 [transforms.nginx_access]
 type = "remap"
-inputs = ["nginx_access_logfmt"]
+inputs = ["nginx_access_raw"]
 source = '''
 if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKER")) {
   abort
 }
 
+.log_group = "nginx-access"
 .app = "nginx"
 .chan = "access"
 .lvl = "INFO"
 
-.parsed = parse_logfmt!(.message)
+.parsed = parse_json!(.message)
 .parsed.msg = ""
-.logfmt_order = ["method", "request_uri", "status", "host", "scheme"]
+
+if !is_nullish(.parsed.ts) {
+  .ts = parse_timestamp(.parsed.ts, "%+") ?? null
+}
 
 status_int = int(.parsed.status) ?? 200
 if status_int >= 500 {
@@ -27,6 +32,7 @@ if status_int >= 500 {
 }
 '''
 
+# nginx error logs
 [sources.nginx_error_raw]
 type = "file"
 include = ["/var/log/nginx/error.log", "/var/log/nginx/error.log.1"]
@@ -40,6 +46,7 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "nginx-error"
 .app = "nginx"
 .chan = "error"
 .parsed = parse_nginx_log(.message, "error") ?? {}

--- a/etc/vector/vector.d/10-php.toml
+++ b/etc/vector/vector.d/10-php.toml
@@ -1,3 +1,5 @@
+# php error logs
+# has some overlap with deskpro app logs -- many PHP errors get caught and logged to app logs
 [sources.php_error_raw]
 type = "file"
 include = ["/var/log/php/error.log", "/var/log/php/error.log.1"]
@@ -17,11 +19,16 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "php-error"
 .lvl = "ERROR"
 .app = "php"
 .chan = "error"
 
-.parsed = parse_regex(.message, r'^(?P<ts>\[\d+\-\w+\-\d+ \d+:\d+:\d+ .*?\]) (?P<msg>.*)$') ?? {}
+.parsed = parse_regex(.message, r'(?m)^\[(?P<ts>\d+\-\w+\-\d+ \d+:\d+:\d+).*?\] (?P<msg>(.|\n)*)$') ?? {}
+
+if !is_nullish(.parsed.ts) {
+  .ts = parse_timestamp(.parsed.ts, "%d-%b-%Y %H:%M:%S") ?? null
+}
 
 if !is_nullish(.parsed.msg) {
   msg = string(.parsed.msg) ?? ""
@@ -33,6 +40,7 @@ if !is_nullish(.parsed.msg) {
 }
 '''
 
+# php_fpm errors will be things like max children being exceeded
 [sources.php_fpm_error_raw]
 type = "file"
 include = ["/var/log/php/fpm_error.log", "/var/log/php/fpm_error.log.1"]
@@ -42,6 +50,7 @@ ignore_not_found = true
 type = "remap"
 inputs = ["php_fpm_error_raw"]
 source = '''
+.log_group = "php_fpm-error"
 .app = "php_fpm"
 .chan = "error"
 .parsed = parse_regex(.message, r'^(?P<ts>\[\d+\-\w+\-\d+ \d+:\d+:\d+\]) (?P<lvl>\w+): (?P<msg>.*)$') ?? {}

--- a/etc/vector/vector.d/10-supervisor.toml
+++ b/etc/vector/vector.d/10-supervisor.toml
@@ -1,3 +1,8 @@
+# These are basically supervisor logs
+# or stdout from processes that supervisor manages
+# that don't have their own log handling elsewhere.
+
+# Supervisors own logs
 [sources.supervisord_raw]
 type = "file"
 include = [
@@ -14,21 +19,14 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "supervisor-procs"
 .app = "supervisord"
 .chan = "process"
 .parsed = parse_regex(.message, r'^(?P<ts>\d+\-\d+\-\d+ \d+:\d+:\d+),\d+ (?P<lvl>\w+) (?P<msg>.*)$') ?? {}
-.ts = to_timestamp(.parsed.ts) ?? now()
+.ts = parse_timestamp(.parsed.ts, "%Y-%m-%d %H:%M:%S") ?? now()
 '''
 
-[sources.vector_raw]
-type = "internal_logs"
-
-[sinks.vector_logs]
-type = "file"
-inputs = ["vector_raw"]
-path = "/var/log/vector.log"
-encoding.codec = "json"
-
+# nginx stdout -- typically empty unless there's a very low-level error
 [sources.nginx_process_raw]
 type = "file"
 include = [
@@ -45,11 +43,13 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "supervisor-procs"
 .app = "nginx"
 .chan = "process"
 .lvl = "INFO"
 '''
 
+# php_fpm stdout -- typically empty unless there's a very low-level error
 [sources.php_fpm_raw]
 type = "file"
 include = [
@@ -66,6 +66,7 @@ if is_string(.message) && contains(string!(.message), get_env_var!("VECTOR_MARKE
   abort
 }
 
+.log_group = "supervisor-procs"
 .app = "php_fpm"
 .chan = "process"
 .lvl = "INFO"

--- a/etc/vector/vector.d/90-output.toml.tmpl
+++ b/etc/vector/vector.d/90-output.toml.tmpl
@@ -11,7 +11,7 @@ inputs = [
   "php_fpm_error",
 
   "deskpro_logs",
-  "deskpro_tasks",
+  "deskpro_services"
 ]
 source = '''
 
@@ -23,7 +23,16 @@ if is_nullish(.lvl) {
   .lvl = string(.parsed.lvl) ?? string(.parsed.level) ?? string(.parsed.level_name) ?? string(.parsed.severity) ?? "INFO"
 }
 
-.ts = to_timestamp(.parsed.ts) ?? to_timestamp(.parsed.timestamp) ?? to_timestamp(.ts) ?? now()
+if is_nullish(.ts) {
+  if is_timestamp(.parsed.ts) {
+    .ts = .parsed.ts
+  } else if is_timestamp(.parsed.timestamp) {
+    .ts = .parsed.timestamp
+  } else {
+    .ts = now()
+  }
+}
+
 .lvl = upcase(.lvl) ?? .lvl
 
 .app = string(.app) ?? null
@@ -36,12 +45,19 @@ if is_nullish(.chan) {
   .chan = "general"
 }
 
+.log_group = string(.log_group) ?? null
+if is_nullish(.log_group) {
+  .log_group = .app + "-" + .chan
+}
+
 .container_name = "{{ getenv "CONTAINER_NAME" }}"
 
 data = {
   "ts": format_timestamp(.ts, format: "%Y-%m-%dT%H:%M:%SZ") ?? .ts,
+  "ts_read": format_timestamp(now(), format: "%Y-%m-%dT%H:%M:%SZ") ?? null,
   "lvl": .lvl,
   "container_name": .container_name,
+  "log_group": .log_group,
   "app": .app,
   "chan": .chan,
   "msg": string(.parsed.msg) ?? string(.parsed.message) ?? string(.message) ?? ""
@@ -72,31 +88,8 @@ if is_object(.parsed) {
   del(.parsed)
 }
 
-.logprops = compact(merge(data, extra))
+. = compact(merge(data, extra))
 '''
-
-{{if eq "logfmt" (getenv "LOGS_OUTPUT_FORMAT") }}
-[transforms.all_formatted]
-type = "remap"
-inputs = ["all"]
-source = '''
-logfmt_order=["ts", "app", "chan", "lvl", "msg", "container_name"]
-if is_array(.logfmt_order) {
-  logfmt_order = unique(append(logfmt_order, .logfmt_order) ?? logfmt_order)
-}
-.orig_message = .message
-.message = encode_logfmt(.logprops, logfmt_order) ?? .orig_message
-'''
-{{else}}
-[transforms.all_formatted]
-type = "remap"
-inputs = ["all"]
-source = '''
-
-.orig_message = .message
-.message = encode_json(.logprops)
-'''
-{{end}}
 
 {{if eq "dir" (getenv "LOGS_EXPORT_TARGET") }}
   {{if eq (getenv "LOGS_EXPORT_DIR") "/dev/null" }}
@@ -105,24 +98,24 @@ source = '''
   {{else}}
     [sinks.out_file]
     type = "file"
-    inputs = ["all_formatted"]
-    path = "{{getenv "LOGS_EXPORT_DIR"}}/{{ getenv "LOGS_EXPORT_FILENAME" "{{.app}}.log" }}"
-    encoding.codec = "raw_message"
+    inputs = ["all"]
+    path = "{{getenv "LOGS_EXPORT_DIR"}}/{{ getenv "LOGS_EXPORT_FILENAME" "{{.log_group}}.log" }}"
+    encoding.codec = "json"
     encoding.timestamp_format = "rfc3339"
   {{end}}
 {{else if eq "cloudwatch" (getenv "LOGS_EXPORT_TARGET") }}
 [sinks.out_cloudwatch_logs]
 type = "aws_cloudwatch_logs"
-inputs = ["all_formatted"]
+inputs = ["all"]
 group_name = "{{ getenv "LOGS_EXPORT_CLOUDWATCH_GROUP_NAME" "deskpro" }}"
 stream_name = "{{ getenv "LOGS_EXPORT_CLOUDWATCH_STREAM_NAME" "{{.app}}/{{.chan}}/{{.container_name}}" }}"
-encoding.codec = "raw_message"
+encoding.codec = "json"
 encoding.timestamp_format = "rfc3339"
 {{else if eq "stdout" (getenv "LOGS_EXPORT_TARGET") }}
 [sinks.out_docker]
 type = "console"
-inputs = ["all_formatted"]
-encoding.codec = "raw_message"
+inputs = ["all"]
+encoding.codec = "json"
 encoding.timestamp_format = "rfc3339"
 target = "stdout"
 {{end}}

--- a/etc/vector/vector.d/90-output.toml.tmpl
+++ b/etc/vector/vector.d/90-output.toml.tmpl
@@ -106,7 +106,7 @@ source = '''
     [sinks.out_file]
     type = "file"
     inputs = ["all_formatted"]
-    path = "{{getenv "LOGS_EXPORT_DIR"}}/{{ getenv "LOGS_EXPORT_FILENAME" "{{.app}}/{{.chan}}.log" }}"
+    path = "{{getenv "LOGS_EXPORT_DIR"}}/{{ getenv "LOGS_EXPORT_FILENAME" "{{.app}}.log" }}"
     encoding.codec = "raw_message"
     encoding.timestamp_format = "rfc3339"
   {{end}}

--- a/test/Earthfile
+++ b/test/Earthfile
@@ -137,23 +137,22 @@ test-custom-logs-group:
         && chmod 0775 /tmp/deskpro-logs
     WITH DOCKER --load deskpro/docker-product-base:test=+base-image
         RUN \
-            # first run - simulate that the migrations need to run
             docker run -d --name test \
                 -e CONTAINER_NAME=logtest \
                 -e LOGS_GID=1988 \
+                -e FAST_SHUTDOWN=0 \ # need to disable fast shutdown so vector has time to write log file we're testing
                 -v /tmp/deskpro-logs:/deskpro/logs \
                 deskpro/docker-product-base:test web \
             && docker exec test /bin/sh -c 'cd /test/serverspec && rspec spec/scenarios/custom_log_group/01_custom_log_group_spec.rb' \
-            && docker exec test /usr/bin/php -r 'echo $doesNotExist;' \
+            && docker exec test /usr/bin/php -r 'echo $doesNotExist; /* this causes an error to be logged */' \
             && docker stop test
     END
-    RUN echo "/tmp/deskpro-logs/logtest should be owned by logs_group" && stat /tmp/deskpro-logs/logtest | grep 1988
-    RUN echo "/tmp/deskpro-logs/logtest/php/error.log should be owned by logs_group" && stat /tmp/deskpro-logs/logtest/php/error.log  | grep 1988
+    RUN echo "/tmp/deskpro-logs/logtest-php-error.log should be owned by logs_group" && stat /tmp/deskpro-logs/logtest-php-error.log | grep 1988
 
 # Built on top of the product base image, this just adds test sources
 # and simulation sources used when testing various container features.
 base-image:
-    FROM ../+docker-product-base
+    FROM DOCKERFILE -f ../Dockerfile ../
     RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         && apt-get install --no-install-recommends --no-install-suggests -y ruby \
         && rm -rf /var/lib/apt/lists/* \
@@ -161,6 +160,7 @@ base-image:
     ENV BOOT_LOG_LEVEL=TRACE
     ENV BOOT_LOG_LEVEL_EXEC=TRACE
     ENV HTTP_USE_TESTING_CERTIFICATE=true
+    ENV FAST_SHUTDOWN=true
     COPY --dir serverspec /test/serverspec
     COPY --dir simulate-release/* /srv/deskpro
     RUN \

--- a/test/serverspec/spec/always/deps_spec.rb
+++ b/test/serverspec/spec/always/deps_spec.rb
@@ -25,5 +25,5 @@ describe command('gomplate -v') do
 end
 
 describe command('vector -V') do
-  its(:stdout) { should contain('vector 0.31.') }
+  its(:stdout) { should contain('vector 0.39.') }
 end

--- a/test/serverspec/spec/always/paths_spec.rb
+++ b/test/serverspec/spec/always/paths_spec.rb
@@ -99,10 +99,3 @@ describe file('/srv/deskpro/INSTANCE_DATA/deskpro-config.d') do
   it { should be_grouped_into 'root' }
   it { should_not be_writable.by('others') }
 end
-
-describe file('/srv/deskpro/services/messenger-api/.env') do
-  it { should exist }
-  it { should be_owned_by 'root' }
-  it { should be_grouped_into 'root' }
-end
-

--- a/test/serverspec/spec/default_web/default_logging_spec.rb
+++ b/test/serverspec/spec/default_web/default_logging_spec.rb
@@ -5,10 +5,6 @@ describe "Default logging options" do
     system('/usr/local/bin/is-ready --check-tasks --wait --timeout 60 -v') or raise "is-ready failed"
   end
 
-  it "should log in logfmt by default" do
-    expect(ENV['LOGS_OUTPUT_FORMAT']).to eq('logfmt')
-  end
-
   describe file('/var/log/docker-boot.log') do
     it { should exist }
     it { should be_owned_by 'root' }

--- a/usr/local/sbin/container-ready.sh
+++ b/usr/local/sbin/container-ready.sh
@@ -197,21 +197,12 @@ log_message() {
   local logline=""
   local chan="${LOG_CHAN}"
 
-  if [ "$LOGS_OUTPUT_FORMAT" == "logfmt" ]; then
-    if [ -n "$chan" ]; then
-      chan=" chan=$chan "
-    else
-      chan=" "
-    fi
-    logline="ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ") app=container-ready${chan}lvl=$lvl msg=$(echo -n "$2" | jq -Rsa .) container_name=$CONTAINER_NAME"
+  if [ -n "$chan" ]; then
+    chan="\"chan\":\"$chan\","
   else
-    if [ -n "$chan" ]; then
-      chan="\"chan\":\"$chan\","
-    else
-      chan=" "
-    fi
-    logline="{\"ts\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"app\":\"container-ready\",${chan}\"lvl\":\"$lvl\",\"msg\":$(echo -n "$2" | jq -Rsa .),\"container_name\":\"$CONTAINER_NAME\"}"
+    chan=" "
   fi
+  logline="{\"ts\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"app\":\"container-ready\",${chan}\"lvl\":\"$lvl\",\"msg\":$(echo -n "$2" | jq -Rsa .),\"container_name\":\"$CONTAINER_NAME\",\"log_group\":\"docker-boot\"}"
 
   echo "$logline" >> /var/log/docker-boot.log
 

--- a/usr/local/sbin/entrypoint.d/05-opc.sh
+++ b/usr/local/sbin/entrypoint.d/05-opc.sh
@@ -23,9 +23,6 @@ opc_main() {
   boot_log_message INFO "[opc] Installing /srv/deskpro/INSTANCE_DATA/deskpro-config.d/01-deskpro-opc.php"
   cp /usr/local/sbin/entrypoint.d/helpers/01-deskpro-opc.php.tmpl /srv/deskpro/INSTANCE_DATA/deskpro-config.d/01-deskpro-opc.php.tmpl
 
-  boot_log_message DEBUG "[opc] Setting LOGS_EXPORT_FILENAME pattern app.chan.log"
-  export LOGS_EXPORT_FILENAME="{{.container_name}}-{{.app}}.{{.chan}}.log"
-
   boot_log_message DEBUG "[opc] Setting DESKPRO_API_BASE_URL_PRIVATE to use loopback if not set"
   if [ -z "$DESKPRO_API_BASE_URL_PRIVATE" ]; then
     export DESKPRO_API_BASE_URL_PRIVATE="http://127.0.0.1:80"

--- a/usr/local/sbin/entrypoint.sh
+++ b/usr/local/sbin/entrypoint.sh
@@ -17,9 +17,6 @@ export DOCKER_CMD_ARGS=("${@:2}")
 export DOCKER_EXEC=""
 export DOCKER_EXEC_ARGS=()
 
-# Main logging format: logfmt or json
-export LOGS_OUTPUT_FORMAT="${LOGS_OUTPUT_FORMAT:-logfmt}"
-
 # If this is set, then logs get output to this directory instead of stdout
 export LOGS_EXPORT_DIR="${LOGS_EXPORT_DIR:-}"
 
@@ -117,12 +114,6 @@ main() {
   fi
 
   boot_log_message TRACE "Docker command: $DOCKER_CMD ${DOCKER_CMD_ARGS[*]}"
-
-  if [ "$LOGS_OUTPUT_FORMAT" != "logfmt" ] && [ "$LOGS_OUTPUT_FORMAT" != "json" ]; then
-    export LOGS_OUTPUT_FORMAT=logfmt
-    boot_log_message ERROR "Unknown LOGS_OUTPUT_FORMAT: $LOGS_OUTPUT_FORMAT. Expected logfmt or json."
-  fi
-
   run_entrypoint_script_dir "/usr/local/sbin/entrypoint.d"
   run_entrypoint_script_dir "/deskpro/entrypoint.d"
   unset run_entrypoint_script_dir
@@ -278,11 +269,7 @@ boot_log_message() {
   local lvl="${1^^}"
   local logline=""
 
-  if [ "$LOGS_OUTPUT_FORMAT" == "logfmt" ]; then
-    logline="ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ") app=entrypoint lvl=$lvl msg=$(echo -n "$2" | jq -Rsa .) container_name=$CONTAINER_NAME"
-  else
-    logline="{\"ts\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"app\":\"entrypoint\",\"lvl\":\"$lvl\",\"msg\":$(echo -n "$2" | jq -Rsa .),\"container_name\":\"$CONTAINER_NAME\"}"
-  fi
+  logline="{\"ts\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",\"app\":\"entrypoint\",\"lvl\":\"$lvl\",\"msg\":$(echo -n "$2" | jq -Rsa .),\"container_name\":\"$CONTAINER_NAME\",\"log_group\":\"docker-boot\"}"
 
   echo "$logline" >> /var/log/docker-boot.log
 

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -426,14 +426,7 @@
     "name": "LOGS_EXPORT_FILENAME",
     "description": "Override of the logs export filename.",
     "type": "string",
-    "default": "{{.app}}/{{.chan}}.log"
-  },
-  {
-    "name": "LOGS_OUTPUT_FORMAT",
-    "description": "Output format for logs.",
-    "type": "string",
-    "example": "logfmt or json",
-    "default": "logfmt"
+    "default": "{{.container_name}}-{{.log_group}}.log"
   },
   {
     "name": "NGINX_ERROR_LOG_LEVEL",


### PR DESCRIPTION
There are two backwards incompatible changes here:
- Removed LOGS_OUTPUT_FORMAT option -- only json everywhere by default. If you still wanted to use some other format, then you'd need to use custom vector config to send it and format it the way you want.
- Changed the default LOGS_EXPORT_FILENAME to group similar log messages together to reduce number of exported files by default.

As such, we should bump the version.

---

Fixes:

* A number of timestamps were not being parsed properly, leading to "ts" always being the processing time rather than the actual time that might exist in the real source log
* Multi-line processing of PHP error log wasn't working properly

---

*Exported Log Files*

Added a new "log_group" property to each log transformer to organize messages into
logical groups. This is used in the new default LOGS_EXPORT_FILENAME format. This
change reduces the number of distinct files that get written to disk:

```
my-exported-logs/
  deskpro-app.log                # deskpro application logs (e.g. from PHP land)
  deskpro-tasks.log              # output from running cron
  deskpro-email_collect.log      # output from email collection service (if enabeld)
  deskpro-email_process.log      # output from email processing service (if enabeld)
  deskpro-svc_messenger.log      # output from svc_messenger service
  deskpro-svc_messenger_api.log  # output from svc_messenger_api service
  nginx-access.log               # nginx access log
  nginx-error.log                # nginx error log
  php-error.log                  # php error log
  php_fpm-error.log              # php fpm error log
  supervisor-procs.log           # supervisor output (and any low level output from php_fpm/nginx that might get raised on start)
```