### PR TITLE
Bug/sc 162396/fix windows line endings in custom pool config

### DIFF
--- a/usr/local/sbin/container-ready.sh
+++ b/usr/local/sbin/container-ready.sh
@@ -206,6 +206,7 @@ log_message() {
 
   echo "$logline" >> /var/log/docker-boot.log
 
+  LOGS_EXPORT_DIR=$(container-var LOGS_EXPORT_DIR --default "")
   if [ -n "$LOGS_EXPORT_DIR" ]; then
     echo "$logline" >> "$LOGS_EXPORT_DIR/docker-boot.log"
   fi

--- a/usr/local/sbin/entrypoint.d/05-opc.sh
+++ b/usr/local/sbin/entrypoint.d/05-opc.sh
@@ -43,6 +43,7 @@ opc_main() {
 
       # copy the config and perform in-place modifications to ensure that the config is valid
       cat "/deskpro/config/${pool}.conf" \
+        | tr -d '\r' \
         | sed 's/^user = php$/user = dp_app/g' \
         | sed 's/^group = php$/group = dp_app/g' \
         | sed "s/^listen = \/run\/php-fpm\/${pool}.sock$/listen = \/run\/php_fpm_${pool}.sock/g" \


### PR DESCRIPTION
- Correctly replace entries in files that contains windows line endings.
- Set the environment variable for the `LOGS_EXPORT_DIR` correctly when the script is called from supervisor.
