### PR TITLE
Chore/sc 165329/restore stdout in docker product base

### DIFF
--- a/etc/nginx/conf.d/deskpro_server_params.tmpl
+++ b/etc/nginx/conf.d/deskpro_server_params.tmpl
@@ -19,7 +19,7 @@ gzip_proxied expired no-cache no-store private auth;
 fastcgi_buffering off;
 proxy_request_buffering off;
 proxy_buffering off;
-client_max_body_size 100M;
+client_max_body_size {{ getenv "NGINX_CLIENT_MAX_BODY_SIZE" "100M" }};;
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/etc/nginx/conf.d/deskpro_server_params.tmpl
+++ b/etc/nginx/conf.d/deskpro_server_params.tmpl
@@ -19,7 +19,7 @@ gzip_proxied expired no-cache no-store private auth;
 fastcgi_buffering off;
 proxy_request_buffering off;
 proxy_buffering off;
-client_max_body_size {{ getenv "NGINX_CLIENT_MAX_BODY_SIZE" "100M" }};;
+client_max_body_size {{ getenv "NGINX_CLIENT_MAX_BODY_SIZE" "100M" }};
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/etc/supervisor/conf.d/logging.conf.tmpl
+++ b/etc/supervisor/conf.d/logging.conf.tmpl
@@ -6,10 +6,16 @@ numprocs=1
 startsecs=0
 autostart=true
 autorestart=true
+{{if eq "stdout" (getenv "LOGS_EXPORT_TARGET") }}stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+redirect_stderr=false
+{{else}}
 redirect_stderr=true
 stdout_logfile=/var/log/vector.log
 stdout_logfile_maxbytes=10000000
-stdout_logfile_backups=0
+stdout_logfile_backups=0{{end}}
 stopsignal=TERM
 stopwaitsecs={{ getenv "FAST_SHUTDOWN" "false" | ternary "0" "8" }}
 # makes vector start first and shut down last so it

--- a/usr/local/sbin/entrypoint.d/20-certs.sh
+++ b/usr/local/sbin/entrypoint.d/20-certs.sh
@@ -7,7 +7,10 @@ certs_main() {
   custom_https_cert
   custom_ca_certs
   custom_mysql_cert
-  update-ca-certificates
+  if [ "$UPDATE_CERT_BUNDLE" = true ]; then
+    boot_log_message INFO "Updating CA certificate bundle"
+    update-ca-certificates
+  fi
 }
 
 # HTTPS cert for web server to enable port 443
@@ -16,10 +19,12 @@ custom_https_cert() {
     boot_log_message INFO "Installing custom SSL certificate for HTTPS"
     cp /deskpro/ssl/certs/deskpro-https.crt /etc/ssl/certs/deskpro-https.crt
     cp /deskpro/ssl/private/deskpro-https.key /etc/ssl/private/deskpro-https.key
+    export UPDATE_CERT_BUNDLE=true
   elif [ "$(container-var HTTP_USE_TESTING_CERTIFICATE)" == "true" ]; then
     boot_log_message WARNING "Using testing SSL certificate for HTTPS"
     cp /usr/local/share/deskpro/deskpro-testing.crt /etc/ssl/certs/deskpro-https.crt
     cp /usr/local/share/deskpro/deskpro-testing.key /etc/ssl/private/deskpro-https.key
+    export UPDATE_CERT_BUNDLE=true
   fi
 
   if [ -f "/etc/ssl/certs/deskpro-https.crt" ]; then
@@ -35,6 +40,7 @@ custom_ca_certs() {
     boot_log_message INFO "Installing custom CA certificates"
     cp -r /deskpro/ssl/ca-certificates/* /usr/local/share/ca-certificates/
     chown -R root:root /usr/local/share/ca-certificates
+    export UPDATE_CERT_BUNDLE=true
   fi
 }
 
@@ -49,6 +55,7 @@ custom_mysql_cert() {
     # and then put the CA cert into the OS dir
     if [ -f /deskpro/ssl/mysql/ca.pem ]; then
       cp /deskpro/ssl/mysql/ca.pem /usr/local/share/ca-certificates/deskpro-mysql-ca.pem
+      export UPDATE_CERT_BUNDLE=true
     fi
   fi
 }

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -429,6 +429,12 @@
     "default": "{{.container_name}}-{{.log_group}}.log"
   },
   {
+    "name": "NGINX_CLIENT_MAX_BODY_SIZE",
+    "description": "The client_max_body_size for the ngin configuration.",
+    "type": "string",
+    "default": "100M"
+  },
+  {
     "name": "NGINX_ERROR_LOG_LEVEL",
     "description": "The log level for nginx logs.",
     "type": "string",

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -430,7 +430,7 @@
   },
   {
     "name": "NGINX_CLIENT_MAX_BODY_SIZE",
-    "description": "The client_max_body_size for the ngin configuration.",
+    "description": "The client_max_body_size for the nginx configuration.",
     "type": "string",
     "default": "100M"
   },


### PR DESCRIPTION
- Support stdout for logs (docker logs)
- Add env var for Nginx `client_max_body_size`
- Only run `update-ca-certificates` if certs have actually been loaded