### PR TITLE
Use rsync instead of cp to copy certificates

### DIFF
--- a/etc/nginx/nginx.conf.tmpl
+++ b/etc/nginx/nginx.conf.tmpl
@@ -17,6 +17,8 @@ http {
     default_type application/octet-stream;
     server_tokens off;
 
+    large_client_header_buffers {{ getenv "NGINX_LARGE_CLIENT_HEADER_BUFFERS" "4 16k" }};
+
     types_hash_bucket_size 96;
     client_max_body_size 256M;
     tcp_nopush on;

--- a/usr/local/sbin/entrypoint.d/20-certs.sh
+++ b/usr/local/sbin/entrypoint.d/20-certs.sh
@@ -38,7 +38,7 @@ custom_https_cert() {
 custom_ca_certs() {
   if [ -d /deskpro/ssl/ca-certificates ]; then
     boot_log_message INFO "Installing custom CA certificates"
-    cp -r /deskpro/ssl/ca-certificates/* /usr/local/share/ca-certificates/
+    rsync -aL --exclude='.*' /deskpro/ssl/ca-certificates/ /usr/local/share/ca-certificates/
     chown -R root:root /usr/local/share/ca-certificates
     export UPDATE_CERT_BUNDLE=true
   fi

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -212,6 +212,12 @@
     "default": "deskpro"
   },
   {
+    "name": "DESKPRO_ES_TIKA_HOST",
+    "description": "Full URL to Apache Tika service used for attachment indexing.",
+    "type": "string",
+    "example": "http://tika.example.com:9998"
+  },
+  {
     "name": "DESKPRO_ES_URL",
     "description": "Full URL to Elasticsearch server (no trailing slash).",
     "type": "string",

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -504,6 +504,12 @@
     "default": "warn"
   },
   {
+    "name": "NGINX_LARGE_CLIENT_HEADER_BUFFERS",
+    "description": "The number and size of buffers used for reading large client request headers.",
+    "type": "string",
+    "default": "4 16k"
+  },
+  {
     "name": "NGINX_WORKER_CONNECTIONS",
     "description": "The number of simultaneous connections that can be handled by each worker connection.",
     "type": "integer",

--- a/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
+++ b/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
@@ -72,6 +72,10 @@ $CONFIG['elastic'] = [
     'retries' => 3,
     'index_name' => {{ $es_index_name | squote }},
     'tenant_id' => {{ (printf "%s%s" $es_tenant_id (test.Ternary "_tenant" "" (eq $es_tenant_id $es_index_name))) | squote }},
+
+    {{if getenv "DESKPRO_ES_TIKA_HOST"}}
+    'tika_host' => {{ (getenv "DESKPRO_ES_TIKA_HOST") | squote }},
+    {{end}}
 ];
 
 #######################################################################


### PR DESCRIPTION
# Change certificate installation

Changing the `cp` to `rsync` to avoid errors when the `/deskpro/ssl/ca-certificates/` directory is present but empty - otherwise you get
```
cp: cannot stat '/deskpro/ssl/ca-certificates/*': No such file or directory
```
when the container boots.

# Add Tika host env var
Enable configuring a Tika host with the `DESKPRO_ES_TIKA_HOST` env var

# Add additional Nginx configuration
Add additional env vars for Nginx configuration (`NGINX_LARGE_CLIENT_HEADER_BUFFERS`).