### PR TITLE
Additional NewRelic configuration

### DIFF
--- a/etc/php/8.3/mods-available/newrelic.ini.tmpl
+++ b/etc/php/8.3/mods-available/newrelic.ini.tmpl
@@ -12,6 +12,9 @@ newrelic.daemon.location = "/usr/local/bin/newrelic-daemon"
 newrelic.daemon.address = {{ getenv "DESKPRO_NR_DAEMON_ADDRESS" "" | quote }}
 {{end}}
 newrelic.framework = "no_framework"
+newrelic.browser_monitoring.auto_instrument = {{ (getenv "DESKPRO_NR_INSTRUMENT_BROWSER" "false") | conv.ToBool | ternary "true" "false" }}
+
+{{ getenv "DESKPRO_NR_INI_OVERRIDES" }}
 {{else}}
 # To enable newrelic extension, set DESKPRO_ENABLE_NEWRELIC=true
 # extension = "newrelic.so"

--- a/usr/local/sbin/entrypoint.d/90-newrelic.sh
+++ b/usr/local/sbin/entrypoint.d/90-newrelic.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#######################################################################
+# This source handles setting environment variables required for 
+# NewRelic.
+#######################################################################
+
+set_nr_env() {
+    if [ "$DESKPRO_ENABLE_NEWRELIC" == "true" ]; then
+        if [ -f /etc/deskpro-release ]; then
+            source /etc/deskpro-release
+        else
+            boot_log_message DEBUG "[set_nr_env] Unable to load release file - attempting to load from env vars"
+        fi
+        boot_log_message DEBUG "[set_nr_env] Setting custom NewRelic env vars"
+        export NEW_RELIC_METADATA_RELEASE_TAG=${DESKPRO_VERSION:-"Unknown"}
+        export NEW_RELIC_METADATA_COMMIT=${DESKPRO_COMMIT_ID:-""}
+    fi
+}
+
+set_nr_env
+unset set_nr_env

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -258,6 +258,17 @@
     "example": "1.2.3.4:31339"
   },
   {
+    "name": "DESKPRO_NR_INI_OVERRIDES",
+    "description": "NewRelic configuration to set and/or override.",
+    "type": "string"
+  },
+  {
+    "name": "DESKPRO_NR_INSTRUMENT_BROWSER",
+    "description": "Whether to enable browser instrumentation in NewRelic or not.",
+    "type": "boolean",
+    "default": "false"
+  },
+  {
     "name": "DESKPRO_NR_LICENSE",
     "description": "License key for NewRelic integration.",
     "type": "string"


### PR DESCRIPTION
# Release tagging

Add the ability to set NewRelic env vars in an entrypoint script so the daemon can annotate traces with release information only when NewRelic is enabled.

# Additional configuration

Add an env var (`DESKPRO_NR_INSTRUMENT_BROWSER`) to allow optional enabling of the browser instrumentation functionality in NewRelic.
There is also an additional catch-all env var to allow for the definition of any other configuration params e.g.:
```
services:
  web:
    environment:
      DESKPRO_ENABLE_NEWRELIC: true
      ...
      DESKPRO_NR_INI_OVERRIDES: |-
        newrelic.guzzle.enabled=false
        newrelic.feature_flag=false
```