### PR TITLE
fix: patch esbuild and openssl CVEs flagged by Aikido

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,8 +213,13 @@ COPY --from=node:22.22.3-bookworm /usr/local/lib/node_modules /usr/local/lib/nod
 # Upgrade npm -- the npm bundled with node ships a vulnerable picomatch
 # (CVE-2026-33671); this pinned npm pulls the patched picomatch 4.0.4.
 ARG NPM_VERSION="11.16.0"
+ARG TSX_VERSION="4.22.4"
+# tsx vendors esbuild; force patched 0.28.1 (GHSA-gv7w-rqvm-qjhr, GHSA-g7r4-m6w7-qqqr)
+ARG ESBUILD_VERSION="0.28.1"
 RUN npm install --global "npm@${NPM_VERSION}" \
-    && npm install --global tsx
+    && npm install --global "tsx@${TSX_VERSION}" \
+    && npm install --prefix /usr/local/lib/node_modules/tsx --save-exact "esbuild@${ESBUILD_VERSION}" \
+    && /usr/local/lib/node_modules/tsx/node_modules/esbuild/bin/esbuild --version
 
 # Install system packages needed for verification and runtime
 RUN apt-get update && apt-get install -y \
@@ -232,6 +237,18 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Pin openssl stack to patched release (CVE-2026-45447); dedicated layer busts
+# stale apt-layer cache that can freeze stage1 at the vulnerable deb13u1.
+ARG OPENSSL_VERSION="3.5.6-1~deb13u2"
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       "openssl=${OPENSSL_VERSION}" \
+       "libssl3t64=${OPENSSL_VERSION}" \
+       "openssl-provider-legacy=${OPENSSL_VERSION}" \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && openssl version -v
 
 # Verify installations
 RUN ldconfig \


### PR DESCRIPTION
## What

Patches the fixable Aikido-flagged CVEs in the base image.

- **esbuild** — pin `tsx@4.22.4`, force `esbuild@0.28.1` over tsx's vendored copy (GHSA-gv7w-rqvm-qjhr RCE via `NPM_CONFIG_REGISTRY`, GHSA-g7r4-m6w7-qqqr path traversal). Build now verifies the nested binary.
- **openssl / libssl3t64 / openssl-provider-legacy** — pin to `3.5.6-1~deb13u2` (CVE-2026-45447, use-after-free DoS/RCE) in a dedicated layer. The base image and `apt upgrade` already carry deb13u2, but a cache-reused build can freeze stage1's apt layers at the vulnerable deb13u1; the dedicated layer busts that cache and fails the build if the patch ever disappears.

## Not fixed (blocked upstream)

newrelic-daemon Go CVEs (golang.org/x/net CVE-2026-39821 critical, stdlib CVE-2026-27145, golang.org/x/sys CVE-2026-39824 + x/net mediums) are baked into the prebuilt agent. `12.7.0.36` is the **latest** upstream release and ships Go 1.26.3 / x/net 0.48.0 / x/sys 0.39.0 — no build with the fixed deps exists yet. Recommend snoozing in Aikido and re-checking each cycle.

## Build note

Rebuild CI with `--pull --no-cache` (or at least `--pull`) so the `FROM debian:13.5-slim` base resolves fresh — the pin defeats apt-layer cache, `--pull` defeats base-image cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)