### PR TITLE
test: guard against nginx default.conf regression

### DIFF
--- a/test/serverspec/spec/always/nginx_spec.rb
+++ b/test/serverspec/spec/always/nginx_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+# The nginx.org package ships a
+# default site at /etc/nginx/conf.d/default.conf that listens on port 80 and
+# shadows Deskpro's own server blocks, causing instance-API requests to 404.
+# The Dockerfile removes it after install. A future nginx version bump (or any
+# reinstall that re-adds the file) must not bring it back, so assert it is gone.
+describe file('/etc/nginx/conf.d/default.conf') do
+  it { should_not exist }
+end


### PR DESCRIPTION
## What

Adds an `always/` invariant ([`nginx_spec.rb`](test/serverspec/spec/always/nginx_spec.rb)) asserting `/etc/nginx/conf.d/default.conf` does not exist in the image.

## Why

The nginx.org package ships a default site at that path (listens on `:80`, shadows Deskpro's own server blocks → instance-API requests 404'd). [PR #101](https://github.com/deskpro/docker-product-base/pull/101) removed it with `rm -f`. This test guards the invariant so a future `NGINX_VERSION` bump — or any reinstall that re-adds the file — fails CI instead of silently regressing.

## Verification

Confirmed against the published images:
- `deskpro/docker-product-base:main` (has the fix) → file absent → **test passes**
- `deskpro/docker-product-base:update` (pre-fix) → file present → **test fails**

So the assertion genuinely distinguishes fixed from regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)