### PR TITLE
fix: patch libssh2 CVE-2026-55200 flagged by Aikido

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -238,17 +238,23 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Pin openssl stack to patched release (CVE-2026-45447); dedicated layer busts
-# stale apt-layer cache that can freeze stage1 at the vulnerable deb13u1.
+# Pin patched security releases in a dedicated layer; busts stale apt-layer
+# cache that can freeze earlier stages at a vulnerable version.
+#   openssl stack  -- CVE-2026-45447 (use-after-free, DoS/RCE)
+#   libssh2 (via libcurl) -- CVE-2026-55200 (use-after-free, PoC exists)
 ARG OPENSSL_VERSION="3.5.6-1~deb13u2"
+ARG LIBSSH2_VERSION="1.11.1-1+deb13u1"
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        "openssl=${OPENSSL_VERSION}" \
        "libssl3t64=${OPENSSL_VERSION}" \
        "openssl-provider-legacy=${OPENSSL_VERSION}" \
+       "libssh2-1t64=${LIBSSH2_VERSION}" \
+       "libssh2-1-dev=${LIBSSH2_VERSION}" \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
-    && openssl version -v
+    && openssl version -v \
+    && dpkg-query -W libssh2-1t64
 
 # Verify installations
 RUN ldconfig \


### PR DESCRIPTION
## What

Pins `libssh2-1t64` and `libssh2-1-dev` to `1.11.1-1+deb13u1` in the existing security-pin layer (alongside openssl).

## Why

**CVE-2026-55200** (high, 84) — use-after-free in libssh2, **PoC exists**. libssh2 is pulled transitively via `libcurl4-openssl-dev`. The patched `deb13u1` lives in `debian-security`, so a cache-clean `apt upgrade` would catch it — the explicit pin makes it deterministic and fails the build loudly if the patch ever disappears.

## Verification

- Ran the exact pinned install against `deskpro/docker-product-base:main`: both packages upgrade cleanly `1.11.1-1` → `1.11.1-1+deb13u1`, no conflicts.
- Build pipeline run against `mg/update` looks good.

## Not in this PR (from the same Aikido export)

- **undici** (low ×2, prototype pollution) — npm bundles undici 6.27.0 (latest 6.x); Aikido's patched version is 7.x, which npm can't ship without breaking. npm-internal, no known exploit → recommend snoozing in Aikido.
- **newrelic-daemon Go CVEs** (incl. the critical `golang.org/x/net` CVE-2026-39821) — blocked upstream; 12.7.0.36 is the latest NR agent and still ships x/net 0.48.0. Recommend snoozing until a newer agent ships.
- **gomplate** / **debian base** — checked, both already at the latest (v5.1.0 / 13.5-slim); no bump available.

## Housekeeping note

`libcurl4-openssl-dev` (a `-dev` headers package) ships in the runtime image and is what drags in libssh2. Worth a separate look at whether the runtime stage needs the `-dev` variants at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)