### PR TITLE
Feature/ops 74 add redis and elasticsearch type env vars to product base

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -58,6 +58,16 @@ docker run --rm php:latest php -r 'echo "DESKPRO_APP_KEY=".var_export(base64_enc
 | `DESKPRO_STORAGE_SETTINGS` | JSON string. Shape depends on `DESKPRO_STORAGE_TYPE`. For S3: `bucket_name`, `bucket_region`, `access_key`, `secret_key`. |
 | `DESKPRO_BLOBS_PATH` | Filesystem path for `fs` storage. Default `/srv/deskpro/INSTANCE_DATA/attachments`. Mount a persistent volume here. |
 
+## Search (Elasticsearch / OpenSearch)
+
+| Variable | Purpose |
+| --- | --- |
+| `DESKPRO_ES_URL` | Full Elasticsearch / OpenSearch URL (may include credentials). No trailing slash. |
+| `DESKPRO_ES_INDEX_NAME` | Index name. Default `deskpro`. |
+| `DESKPRO_ES_TENANT_ID` | Alias / tenant id. Defaults to the index name (suffixed `_tenant` on conflict). |
+| `DESKPRO_ES_TIKA_HOST` | Apache Tika URL for attachment indexing. Optional. |
+| `DESKPRO_ES_ENGINE` | Search engine type. Set to `opensearch` when the backend is OpenSearch. The `type` key is only emitted for `opensearch`. |
+
 ## Redis
 
 The `$CONFIG['redis']` block is only rendered when `DESKPRO_REDIS_HOST` or `DESKPRO_REDIS_URL` is set. When neither is set, no redis config is emitted (and an OPC-provided redis config is left untouched).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -58,6 +58,20 @@ docker run --rm php:latest php -r 'echo "DESKPRO_APP_KEY=".var_export(base64_enc
 | `DESKPRO_STORAGE_SETTINGS` | JSON string. Shape depends on `DESKPRO_STORAGE_TYPE`. For S3: `bucket_name`, `bucket_region`, `access_key`, `secret_key`. |
 | `DESKPRO_BLOBS_PATH` | Filesystem path for `fs` storage. Default `/srv/deskpro/INSTANCE_DATA/attachments`. Mount a persistent volume here. |
 
+## Redis
+
+The `$CONFIG['redis']` block is only rendered when `DESKPRO_REDIS_HOST` or `DESKPRO_REDIS_URL` is set. When neither is set, no redis config is emitted (and an OPC-provided redis config is left untouched).
+
+| Variable | Purpose |
+| --- | --- |
+| `DESKPRO_REDIS_URL` | Full redis connection URL (may include credentials). Overrides host/port when set. |
+| `DESKPRO_REDIS_HOST` | Redis host. Setting this (or `DESKPRO_REDIS_URL`) enables the block. |
+| `DESKPRO_REDIS_USER` | Redis username (redis 6+ ACL). |
+| `DESKPRO_REDIS_PASS` | Redis password. |
+| `DESKPRO_REDIS_PORT` | Redis port. Default `6379`. |
+| `DESKPRO_REDIS_DATABASE` | Redis database number. Default `0`. |
+| `DESKPRO_REDIS_PREFIX` | Optional key prefix. The `prefix` key is only emitted when set. |
+
 ## Install & migrations
 
 | Variable | Purpose |

--- a/test/serverspec/spec/cases/simple/es-engine_spec.rb
+++ b/test/serverspec/spec/cases/simple/es-engine_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe "ES engine: DESKPRO_ES_ENGINE sets the search engine type" do
+  before(:all) do
+    system('/usr/local/bin/is-ready --check-tasks --wait --timeout 60 -v') or raise "is-ready failed"
+  end
+
+  after(:all) do
+    ENV.delete('DESKPRO_ES_ENGINE')
+  end
+
+  it "emits 'type' => 'opensearch' when DESKPRO_ES_ENGINE is opensearch" do
+    ENV['DESKPRO_ES_ENGINE'] = 'opensearch'
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).to contain "'type' => 'opensearch'"
+  end
+
+  it "omits the 'type' key when DESKPRO_ES_ENGINE is unset" do
+    ENV.delete('DESKPRO_ES_ENGINE')
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).not_to contain "'type' =>"
+  end
+
+  it "omits the 'type' key for a non-opensearch engine value" do
+    ENV['DESKPRO_ES_ENGINE'] = 'elasticsearch'
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).not_to contain "'type' =>"
+  end
+end

--- a/test/serverspec/spec/cases/simple/es-engine_spec.rb
+++ b/test/serverspec/spec/cases/simple/es-engine_spec.rb
@@ -9,21 +9,24 @@ describe "ES engine: DESKPRO_ES_ENGINE sets the search engine type" do
     ENV.delete('DESKPRO_ES_ENGINE')
   end
 
+  # Note: use RSpec's literal `include` matcher, not serverspec's `contain`
+  # (which treats its argument as a regex).
+
   it "emits 'type' => 'opensearch' when DESKPRO_ES_ENGINE is opensearch" do
     ENV['DESKPRO_ES_ENGINE'] = 'opensearch'
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).to contain "'type' => 'opensearch'"
+    expect(output).to include "'type' => 'opensearch'"
   end
 
   it "omits the 'type' key when DESKPRO_ES_ENGINE is unset" do
     ENV.delete('DESKPRO_ES_ENGINE')
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).not_to contain "'type' =>"
+    expect(output).not_to include "'type' =>"
   end
 
   it "omits the 'type' key for a non-opensearch engine value" do
     ENV['DESKPRO_ES_ENGINE'] = 'elasticsearch'
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).not_to contain "'type' =>"
+    expect(output).not_to include "'type' =>"
   end
 end

--- a/test/serverspec/spec/cases/simple/redis-config_spec.rb
+++ b/test/serverspec/spec/cases/simple/redis-config_spec.rb
@@ -15,33 +15,37 @@ describe "Redis config: env vars render $CONFIG['redis']" do
     ENV.delete('DESKPRO_REDIS_PREFIX')
   end
 
+  # Note: use RSpec's literal `include` matcher, not serverspec's `contain`.
+  # `contain` treats its argument as a regex, and the rendered PHP contains
+  # metacharacters ($, [, ]) that would break matching.
+
   it "renders the redis block with host and default port when DESKPRO_REDIS_HOST is set" do
     ENV['DESKPRO_REDIS_HOST'] = 'redis'
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).to contain "$CONFIG['redis'] ="
-    expect(output).to contain "'host'     => 'redis'"
-    expect(output).to contain "'port'     => '6379'"
-    expect(output).to contain "'database' => '0'"
+    expect(output).to include "$CONFIG['redis'] = ["
+    expect(output).to include "'host'     => 'redis'"
+    expect(output).to include "'port'     => '6379'"
+    expect(output).to include "'database' => '0'"
   end
 
   it "emits the prefix key only when DESKPRO_REDIS_PREFIX is set" do
     ENV['DESKPRO_REDIS_HOST'] = 'redis'
     ENV['DESKPRO_REDIS_PREFIX'] = 'dp_'
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).to contain "'prefix'   => 'dp_'"
+    expect(output).to include "'prefix'   => 'dp_'"
   end
 
   it "omits the prefix key when DESKPRO_REDIS_PREFIX is unset" do
     ENV['DESKPRO_REDIS_HOST'] = 'redis'
     ENV.delete('DESKPRO_REDIS_PREFIX')
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).not_to contain "'prefix'"
+    expect(output).not_to include "'prefix'"
   end
 
   it "does not render the redis block when no redis vars are set" do
     ENV.delete('DESKPRO_REDIS_HOST')
     ENV.delete('DESKPRO_REDIS_URL')
     output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
-    expect(output).not_to contain "$CONFIG['redis'] ="
+    expect(output).not_to include "$CONFIG['redis']"
   end
 end

--- a/test/serverspec/spec/cases/simple/redis-config_spec.rb
+++ b/test/serverspec/spec/cases/simple/redis-config_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe "Redis config: env vars render $CONFIG['redis']" do
+  before(:all) do
+    system('/usr/local/bin/is-ready --check-tasks --wait --timeout 60 -v') or raise "is-ready failed"
+  end
+
+  after(:all) do
+    ENV.delete('DESKPRO_REDIS_URL')
+    ENV.delete('DESKPRO_REDIS_HOST')
+    ENV.delete('DESKPRO_REDIS_USER')
+    ENV.delete('DESKPRO_REDIS_PASS')
+    ENV.delete('DESKPRO_REDIS_PORT')
+    ENV.delete('DESKPRO_REDIS_DATABASE')
+    ENV.delete('DESKPRO_REDIS_PREFIX')
+  end
+
+  it "renders the redis block with host and default port when DESKPRO_REDIS_HOST is set" do
+    ENV['DESKPRO_REDIS_HOST'] = 'redis'
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).to contain "$CONFIG['redis'] ="
+    expect(output).to contain "'host'     => 'redis'"
+    expect(output).to contain "'port'     => '6379'"
+    expect(output).to contain "'database' => '0'"
+  end
+
+  it "emits the prefix key only when DESKPRO_REDIS_PREFIX is set" do
+    ENV['DESKPRO_REDIS_HOST'] = 'redis'
+    ENV['DESKPRO_REDIS_PREFIX'] = 'dp_'
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).to contain "'prefix'   => 'dp_'"
+  end
+
+  it "omits the prefix key when DESKPRO_REDIS_PREFIX is unset" do
+    ENV['DESKPRO_REDIS_HOST'] = 'redis'
+    ENV.delete('DESKPRO_REDIS_PREFIX')
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).not_to contain "'prefix'"
+  end
+
+  it "does not render the redis block when no redis vars are set" do
+    ENV.delete('DESKPRO_REDIS_HOST')
+    ENV.delete('DESKPRO_REDIS_URL')
+    output = `eval-tpl -f /usr/local/share/deskpro/templates/deskpro-config.php.tmpl`
+    expect(output).not_to contain "$CONFIG['redis'] ="
+  end
+end

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -200,6 +200,12 @@
     "default": "false"
   },
   {
+    "name": "DESKPRO_ES_ENGINE",
+    "description": "Search engine type. Set to 'opensearch' when the backend is OpenSearch instead of Elasticsearch.",
+    "type": "string",
+    "example": "opensearch"
+  },
+  {
     "name": "DESKPRO_ES_INDEX_NAME",
     "description": "Name of Elasticsearch index to use.",
     "type": "string",

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -269,6 +269,18 @@
     "type": "string"
   },
   {
+    "name": "REDIS_URLS",
+    "description": "Redis connection URL(s) for the messenger service. Passed through to the messenger process environment.",
+    "type": "string",
+    "example": "redis://user:password@host.docker.internal:6379"
+  },
+  {
+    "name": "REDIS_KEY_PREFIX",
+    "description": "Redis key prefix for the messenger service. Passed through to the messenger process environment.",
+    "type": "string",
+    "example": "dp_testinst:"
+  },
+  {
     "name": "DESKPRO_LICENSE_KEY",
     "description": "A license key. This would override any in-product license management because it is effectively hard-coded.",
     "type": "string"

--- a/usr/local/share/deskpro/container-var-reference.json
+++ b/usr/local/share/deskpro/container-var-reference.json
@@ -224,6 +224,45 @@
     "example": "https://username:password!#$?*abc@foo.com:9200"
   },
   {
+    "name": "DESKPRO_REDIS_URL",
+    "description": "Full redis connection URL (may include credentials). Overrides host/port when set.",
+    "type": "string",
+    "example": "redis://user:password@redis.example.com:6379/0"
+  },
+  {
+    "name": "DESKPRO_REDIS_HOST",
+    "description": "IP/Hostname of redis server.",
+    "type": "string",
+    "example": "redis"
+  },
+  {
+    "name": "DESKPRO_REDIS_USER",
+    "description": "Username to connect to redis (redis 6+ ACL).",
+    "type": "string"
+  },
+  {
+    "name": "DESKPRO_REDIS_PASS",
+    "description": "Password to connect to redis.",
+    "type": "string"
+  },
+  {
+    "name": "DESKPRO_REDIS_PORT",
+    "description": "Port of redis server.",
+    "type": "string",
+    "default": "6379"
+  },
+  {
+    "name": "DESKPRO_REDIS_DATABASE",
+    "description": "Redis database number.",
+    "type": "string",
+    "default": "0"
+  },
+  {
+    "name": "DESKPRO_REDIS_PREFIX",
+    "description": "Optional key prefix for redis.",
+    "type": "string"
+  },
+  {
     "name": "DESKPRO_LICENSE_KEY",
     "description": "A license key. This would override any in-product license management because it is effectively hard-coded.",
     "type": "string"

--- a/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
+++ b/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
@@ -79,6 +79,26 @@ $CONFIG['elastic'] = [
 ];
 
 #######################################################################
+# redis
+#######################################################################
+
+{{if or (getenv "DESKPRO_REDIS_HOST") (getenv "DESKPRO_REDIS_URL")}}
+$CONFIG['redis'] = [
+    'url'      => {{ (getenv "DESKPRO_REDIS_URL") | squote }},
+    'host'     => {{ (getenv "DESKPRO_REDIS_HOST") | squote }},
+    'username' => {{ (getenv "DESKPRO_REDIS_USER") | squote }},
+    'password' => <<<'__VAL__'
+{{ getenv "DESKPRO_REDIS_PASS" }}
+__VAL__,
+    'port'     => {{ (getenv "DESKPRO_REDIS_PORT" "6379") | squote }},
+    'database' => {{ (getenv "DESKPRO_REDIS_DATABASE" "0") | squote }},
+    {{if getenv "DESKPRO_REDIS_PREFIX"}}
+    'prefix'   => {{ (getenv "DESKPRO_REDIS_PREFIX") | squote }},
+    {{end}}
+];
+{{end}}
+
+#######################################################################
 # broadcaster
 #######################################################################
 

--- a/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
+++ b/usr/local/share/deskpro/templates/deskpro-config.php.tmpl
@@ -76,6 +76,13 @@ $CONFIG['elastic'] = [
     {{if getenv "DESKPRO_ES_TIKA_HOST"}}
     'tika_host' => {{ (getenv "DESKPRO_ES_TIKA_HOST") | squote }},
     {{end}}
+
+    {{if eq (getenv "DESKPRO_ES_ENGINE") "opensearch"}}
+    /*
+     * The type of search engine in use
+     */
+    'type' => {{ (getenv "DESKPRO_ES_ENGINE") | squote }},
+    {{end}}
 ];
 
 #######################################################################


### PR DESCRIPTION
Add Redis and OpenSearch configuration support

This adds new environment variables so Redis and OpenSearch can be configured the same way as the database and Elasticsearch — no custom config files required.